### PR TITLE
Fix roxygen S3 method warnings

### DIFF
--- a/R/ideal.R
+++ b/R/ideal.R
@@ -296,6 +296,8 @@ ideal_. <- function(x, raw_chars = FALSE, code = FALSE, ...) {
 
 
 
+#' @rdname ideal
+#' @export
 m2_parse_function.m2_ideal <- function(x) {
   m2_structure(
     m2_name = "",
@@ -308,6 +310,8 @@ m2_parse_function.m2_ideal <- function(x) {
 }
 
 
+#' @rdname ideal
+#' @export
 m2_parse_function.m2_monomialideal <- function(x) {
   m2_structure(
     m2_name = "",

--- a/R/m2_parser.R
+++ b/R/m2_parser.R
@@ -418,10 +418,21 @@ m2_parse_internal <- function(tokens, start = 1) {
 # class name is m2_M2CLASSNAME in all lower case
 # example: x = list(1,2,3), class(x) = c("m2_verticallist","m2")
 m2_parse_class <- function(x) UseMethod("m2_parse_class")
+
+#' @rdname m2_parser
+#' @export
 m2_parse_class.default <- function(x) x
 
+#' @rdname m2_parser
+#' @export
 m2_parse_class.m2_hashtable <- m2_parse_class.default
+
+#' @rdname m2_parser
+#' @export
 m2_parse_class.m2_optiontable <- m2_parse_class.m2_hashtable
+
+#' @rdname m2_parser
+#' @export
 m2_parse_class.m2_verticallist <- m2_parse_class.m2_hashtable
 
 
@@ -431,14 +442,28 @@ m2_parse_class.m2_verticallist <- m2_parse_class.m2_hashtable
 # x is a list of function parameters
 # class name is m2_M2FUNCTIONNAME in all lower case
 # example: x = list(mpoly("x")), class(x) = c("m2_symbol","m2")
+
 m2_parse_function <- function(x) UseMethod("m2_parse_function")
+
+#' @rdname m2_parser
+#' @export
 m2_parse_function.default <- function(x) stop(paste0("Unsupported function ", class(x)[1]))
 
+#' @rdname m2_parser
+#' @export
 m2_parse_function.m2_hashtable <- function(x) x[[1]]
+
+#' @rdname m2_parser
+#' @export
 m2_parse_function.m2_optiontable <- m2_parse_function.m2_hashtable
+
+#' @rdname m2_parser
+#' @export
 m2_parse_function.m2_verticallist <- m2_parse_function.m2_hashtable
 
 
+#' @rdname m2_parser
+#' @export
 m2_parse_function.m2_symbol <- function(x) {
 
   class(x[[1]]) <- c("m2_symbol","m2")
@@ -447,6 +472,8 @@ m2_parse_function.m2_symbol <- function(x) {
 }
 
 
+#' @rdname m2_parser
+#' @export
 m2_parse_function.m2_monoid <- function(x) {
 
   class(x[[1]]) <- c("m2_monoid","m2")
@@ -455,6 +482,8 @@ m2_parse_function.m2_monoid <- function(x) {
 }
 
 
+#' @rdname m2_parser
+#' @export
 m2_parse_function.m2_tocc <- function(x) {
   m2_structure(complex(real = x[[1]], imaginary = x[[2]]), m2_class = "m2_complex")
 }
@@ -464,11 +493,16 @@ m2_parse_function.m2_tocc <- function(x) {
 # example: x = monoid, params = [x,y,z]
 # example: x = QQ, params = monoid [x..z]
 m2_parse_object_as_function <- function(x, params) UseMethod("m2_parse_object_as_function")
+
+#' @rdname m2_parser
+#' @export
 m2_parse_object_as_function.default <- function(x, params) stop(paste0("Unsupported object ", class(x)[1], " used as function"))
 
 
 # x is a function name
 # dispatch for function call
+#' @rdname m2_parser
+#' @export
 m2_parse_object_as_function.m2_symbol <- function(x, params) {
 
   class(params) <- c(paste0("m2_",tolower(x)),"m2")

--- a/R/matrix.R
+++ b/R/matrix.R
@@ -201,6 +201,8 @@ m2_length <- function(x, code = FALSE, ...) {
 
 
 
+#' @rdname m2_matrix
+#' @export
 m2_parse_function.m2_map <- function(x) {
 
   R1 <- x[[1]]
@@ -289,6 +291,8 @@ print.m2_matrix <- function(x, ...){
 
 
 
+#' @rdname m2_matrix
+#' @export
 m2_parse_function.m2_image <- function(x) {
   m2_structure(
     x[[1]],

--- a/R/ring.R
+++ b/R/ring.R
@@ -199,6 +199,8 @@ coefring_as_ring <- function(coefring) {
 
 
 
+#' @rdname ring
+#' @export
 m2_parse_object_as_function.m2_polynomialring <- function(x, params) {
 
   monoid <- params[[c(1)]]


### PR DESCRIPTION
## Summary
- add `@export` tags for internal S3 methods so roxygen registers them

## Testing
- `R -q -e "devtools::document(roclets = c('rd', 'collate', 'namespace'))"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684739d1df44832fb4ca7a05cb52d0b5